### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,15 +13,15 @@ Chronometer
     :target: http://chronometer.readthedocs.org/en/latest/
     :alt: Documentation
 
-.. image:: https://pypip.in/version/chronometer/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/chronometer.svg?style=flat
     :target: https://pypi.python.org/pypi/chronometer/
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/chronometer/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/chronometer.svg?style=flat
     :target: https://pypi.python.org/pypi/chronometer/
     :alt: Python versions
 
-.. image:: https://pypip.in/license/chronometer/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/chronometer.svg?style=flat
     :target: https://github.com/eisensheng/chronometer/blob/develop/COPYING
     :alt: MIT License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20chronometer))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `chronometer`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.